### PR TITLE
Dropping lodash refs for a local implementation to reduce footprint.

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "0.2.6",
+  "version": "0.2.7-alpha.4",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.20.7",

--- a/forms/package.json
+++ b/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms",
-  "version": "0.2.6",
+  "version": "0.2.7-alpha.4",
   "description": "Simple library with useful React forms components and browser validation.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +15,9 @@
     "test": "VITEST_SEGFAULT_RETRY=3 vitest --run --passWithNoTests",
     "prebuild": "tsc --build tsconfig.build.json --clean && rimraf dist",
     "build": "tsc --build tsconfig.build.json",
-    "watch": "npm run build -- --watch"
+    "predev": "tsc --build tsconfig.json --clean && rimraf dist",
+    "dev": "tsc --build tsconfig.json",
+    "watch": "npm run dev -- --watch"
   },
   "repository": {
     "type": "git",
@@ -62,8 +64,6 @@
     "vitest": "^0.31.0"
   },
   "peerDependencies": {
-    "lodash.defaults": "^4",
-    "lodash.omitby": "^4",
     "react": "^18"
   }
 }

--- a/forms/src/useFieldState.ts
+++ b/forms/src/useFieldState.ts
@@ -1,7 +1,6 @@
 import { ChangeEvent, useState } from 'react'
-import defaults from 'lodash.defaults'
-import omitBy from 'lodash.omitby'
 import { UseFieldStateResult } from './UseFieldStateResult'
+import { defaults, omitBy } from './utils'
 
 /**
  * Manages field state via change handler, values and error state.

--- a/forms/src/utils.test.ts
+++ b/forms/src/utils.test.ts
@@ -1,0 +1,31 @@
+import { defaults, omitBy } from './utils'
+
+describe('omitby', () => {
+	it('should omit matching args', async() => {
+		const result = omitBy({ a: 1, b: 2, c: 3 }, (v) => v % 2 === 0)
+		expect(result).to.deep.equal({ a: 1, c: 3 })
+	})
+	it('should omit matching args', async() => {
+		const result = omitBy([1, 2, 3], (v) => v % 2 === 0)
+		expect(result).to.deep.equal([1, 3])
+	})
+})
+
+describe('defaults', () => {
+	it('should apply defaults in order when target undefined', async() => {
+		const result = defaults(undefined, { a: 1 }, { b: 2 }, { a: 3 })
+		expect(result).to.deep.equal({ a: 1, b: 2 })
+	})
+	it('should apply defaults in order to target instance', async() => {
+		const target = {}
+		const result = defaults(target, { a: 1 }, { b: 2 }, { a: 3 })
+		expect(target).to.deep.equal({ a: 1, b: 2 })
+		expect(target).to.equal(result)
+	})
+	it('should apply defaults for multiple props in order to target instance', async() => {
+		const target = {}
+		const result = defaults(target, { a: 1, b: 4 }, { b: 2, c: 5 }, { a: 3, d: 6 })
+		expect(target).to.deep.equal({ a: 1, b: 4, c: 5, d: 6 })
+		expect(target).to.equal(result)
+	})
+})

--- a/forms/src/utils.ts
+++ b/forms/src/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Return a new shallow copied array/object with values/keys ommitted that match the provided check.
+ * @param values Source values/keys
+ * @param omitWhen Excludes values that return true
+ * @returns Shallow copied object or array without values/keys ommitted.
+ */
 export const omitBy = (values: Record<string, any> | any[], omitWhen: (v: any) => boolean): Record<string, any> | any[] => {
 	if (Array.isArray(values)) return values.filter((v) => !omitWhen(v))
 

--- a/forms/src/utils.ts
+++ b/forms/src/utils.ts
@@ -1,0 +1,28 @@
+export const omitBy = (values: Record<string, any> | any[], omitWhen: (v: any) => boolean): Record<string, any> | any[] => {
+	if (Array.isArray(values)) return values.filter((v) => !omitWhen(v))
+
+	const result = {}
+
+	const keys = Object.keys(values)
+	for (const key of keys) {
+		if (!omitWhen(values[key])) result[key] = values[key]
+	}
+	return result
+}
+
+/**
+ * Applies values from sources to target. First in, wins; subsequent sources ignored.
+ * @param target Target instance to apply defaults; will initialize to empty object if undefined.
+ * @param sources Source objects with default values applied first [left] to last [right].
+ * @returns target
+ */
+export const defaults = (target: Record<string, any> = {}, ...sources: Record<string, any>[]) => {
+	for (const source of sources) {
+		for (const key in source) {
+			if (typeof target[key] === 'undefined' && typeof source[key] !== 'undefined') {
+				target[key] = source[key]
+			}
+		}
+	}
+	return target
+}

--- a/forms/tsconfig.build.json
+++ b/forms/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
 	"extends": "./tsconfig",
+	"compilerOptions": {
+		"sourceMap": false,
+		"declarationMap": false
+	},
 	"exclude": ["node_modules", "**/*.test.*", "**/__tests__/*", "**/__mocks__/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iwsio/forms-root",
-  "version": "0.2.6",
+  "version": "0.2.7-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iwsio/forms-root",
-      "version": "0.2.6",
+      "version": "0.2.7-alpha.4",
       "license": "BSD-3-Clause",
       "workspaces": [
         "forms",
@@ -21,7 +21,7 @@
       }
     },
     "demo": {
-      "version": "0.2.6",
+      "version": "0.2.7-alpha.4",
       "license": "ISC",
       "dependencies": {
         "serve": "^14.2.0"
@@ -80,7 +80,7 @@
     },
     "forms": {
       "name": "@iwsio/forms",
-      "version": "0.2.6",
+      "version": "0.2.7-alpha.4",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -109,8 +109,6 @@
         "vitest": "^0.31.0"
       },
       "peerDependencies": {
-        "lodash.defaults": "^4",
-        "lodash.omitby": "^4",
         "react": "^18"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms-root",
-  "version": "0.2.6",
+  "version": "0.2.7-alpha.4",
   "description": "Simple library with useful React forms components and browser validation.",
   "files": [],
   "engines": {

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -8,7 +8,7 @@
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"incremental": true,
-		"inlineSourceMap": true,
+		"inlineSourceMap": false,
 		"jsx": "react-jsx",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"module": "CommonJS",
@@ -16,6 +16,7 @@
 		"resolveJsonModule": true,
 		"skipDefaultLibCheck": true,
 		"skipLibCheck": true,
+		"sourceMap": true,
 		"target": "ES5",
 		"types": ["vitest/globals"]
 	}


### PR DESCRIPTION
Dropping `lodash.omitby`, and `lodash.defaults` to reduce footprint. 

These two refs were only used with field state, and I thought it would be nice to remove any dependencies for this package other than `react@18` itself. These implementation just offer a quick, shallow replacement. 