### PR TITLE
better real-time onchange tracking, but need to solve showing before …

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms-demo",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.23.3",

--- a/demo/src/content/index.md
+++ b/demo/src/content/index.md
@@ -96,6 +96,8 @@ Finally, `FieldManager` brings it all together and automatically wires up field 
 
 The props on `FieldManager` passthrough to the underlying `<form/>`. You can provide `className` and other HTML attributes commonly used on `<form/>`. For this to work however, you will need to provide at least an initial field state as `fields`. Use `onValidSubmit` to know when the form submit occurred with valid fields.
 
+See the [invalid feedback example](/invalid-feedback) to see how to customize showing errors manually instead of relying on native validation reporting. 
+
 Here is a quick example:
 
 ```tsx
@@ -104,7 +106,7 @@ const Sample = () => {
     // Do whatever you want with fields.
   }
   return (
-    <FieldManager fields={{ field1: "", field2: "", field3: "" }} onValidSubmit={handleValidSubmit} className="custom-form-css">
+    <FieldManager fields={{ field1: "", field2: "", field3: "" }} onValidSubmit={handleValidSubmit} className="custom-form-css" nativeValidation>
       <InputField type="text" name="field1" required pattern="^\w+$" />
       <InputField
         type="number"

--- a/demo/src/content/invalid-feedback.md
+++ b/demo/src/content/invalid-feedback.md
@@ -2,31 +2,32 @@
 
 Using `<FieldManager>`, the value and error state is shared via context API. We can now more easily render error and value status.
 
-To do this, you would use `useFieldManager()` to get the current `fieldErrors` state. Then render wherever you want.
+To do this, use `useFieldManager()` to get a check function `checkFieldError(fieldName: string)`. The result of this function will indicate whether there is an error and it is "reportable" (meaning the form has been submitted at least once). You may also access the real-time error any time through `fieldErrors` state from the hook.
 
 <div class="not-prose">
 
 ```jsx
-const InvalidFeedbackLabel = ({ children }) => <label className="peer-invalid:visible font-light">{children}</label>
-
 export const Field = () => {
-	const { fieldErrors } = useFieldManager()
-	const hasError = useMemo(() => fieldErrors.field != null, [fieldErrors])
+	const { checkFieldError } = useFieldManager()
+	const fieldError = checkFieldError('field')
 
 	return (
-		<label className={`flex flex-row gap-4 items-center ${hasError ? 'text-error' : ''}`}>
-			Generic field:
-			<InputField name="field" required className={`input input-bordered ${hasError ? 'input-error' : ''}`} /> 
-			{hasError && <InvalidFeedbackLabel>{fieldErrors.field}</InvalidFeedbackLabel>}
-		</label>
+		<div className="form-control">
+			<div className="indicator">
+				<InputField name="field" required className={`input input-bordered ${fieldError ? 'input-error' : ''}`} pattern="^[a-zA-Z]+$" />
+				{fieldError && <span className="indicator-item badge badge-error">{fieldError}</span>}
+			</div>
+			<label className="label">
+				<span className="label-text-alt">Required pattern:<code>^[a-zA-Z]+$</code></span>
+			</label>
+		</div>
 	)
 }
 
 export const ResetButton = () => {
-	const { reset } = useFieldManager() // We need to use the field manager reset to reset validation state.
+	const { reset } = useFieldManager()
 	return <button type="reset" className="btn" onClick={() => reset()}>Reset</button>
 }
-
 export const InvalidFeedbackDemo = () => {
 	const [success, setSuccess] = useState(false)
 	const handleSubmit = () => {
@@ -45,7 +46,7 @@ export const InvalidFeedbackDemo = () => {
 						<ResetButton />
 						<button type="submit" className={`btn ${success ? 'btn-success' : ''}`}>Submit</button>
 					</div>
-					<p><em>Submit with empty for error</em></p>
+					<p><em>Submit with empty or any non-alpha character for error.</em></p>
 				</div>
 			</fieldset>
 		</FieldManager>

--- a/demo/src/samples/InvalidFeedback.tsx
+++ b/demo/src/samples/InvalidFeedback.tsx
@@ -1,18 +1,20 @@
 import { FieldManager, InputField, useFieldManager } from '@iwsio/forms'
-import { useMemo, useState } from 'react'
-
-export const InvalidFeedbackLabel = ({ children }) => <label className="peer-invalid:visible font-light">{children}</label>
+import { useState } from 'react'
 
 export const Field = () => {
-	const { fieldErrors } = useFieldManager()
-	const hasError = useMemo(() => fieldErrors.field != null, [fieldErrors])
+	const { checkFieldError } = useFieldManager()
+	const fieldError = checkFieldError('field')
 
 	return (
-		<label className={`flex flex-row gap-4 items-center ${hasError ? 'text-error' : ''}`}>
-			Generic field:
-			<InputField name="field" required className={`input input-bordered ${hasError ? 'input-error' : ''}`} />
-			{hasError && <InvalidFeedbackLabel>{fieldErrors.field}</InvalidFeedbackLabel>}
-		</label>
+		<div className="form-control">
+			<div className="indicator">
+				<InputField name="field" required className={`input input-bordered ${fieldError ? 'input-error' : ''}`} pattern="^[a-zA-Z]+$" />
+				{fieldError && <span className="indicator-item badge badge-error">{fieldError}</span>}
+			</div>
+			<label className="label">
+				<span className="label-text-alt">Required pattern:<code>^[a-zA-Z]+$</code></span>
+			</label>
+		</div>
 	)
 }
 
@@ -38,7 +40,7 @@ export const InvalidFeedbackDemo = () => {
 						<ResetButton />
 						<button type="submit" className={`btn ${success ? 'btn-success' : ''}`}>Submit</button>
 					</div>
-					<p><em>Submit with empty for error</em></p>
+					<p><em>Submit with empty or any non-alpha character for error.</em></p>
 				</div>
 			</fieldset>
 		</FieldManager>

--- a/demo/src/samples/RawExamples.tsx
+++ b/demo/src/samples/RawExamples.tsx
@@ -18,7 +18,7 @@ export function RawExamples() {
 			<RawSampleField
 				title="Numeric fields"
 				label="Step: 1, min: 1, max: 10"
-				help={<>Try <code>abc123</code>, <code>*</code>, or blank</>}
+				help={<>Try <code>1</code>, <code>11</code>, or blank</>}
 			>
 				<InputField type="number" required placeholder="Enter number" min={1} max={10} step={1} className="input input-bordered grow" name="field" />
 			</RawSampleField>

--- a/forms/README.md
+++ b/forms/README.md
@@ -98,6 +98,9 @@ Finally, `FieldManager` brings it all together and automatically wires up field 
 
 The props on `FieldManager` passthrough to the underlying `<form/>`. You can provide `className` and other HTML attributes commonly used on `<form/>`. For this to work however, you will need to provide at least an initial field state as `fields`. Use `onValidSubmit` to know when the form submit occurred with valid fields.
 
+This can be manually styled as well. Use `useFieldManager()` to get a check function `checkFieldError(fieldName: string)`. The result of this function will indicate whether there is an error and it is "reportable" (meaning the form has been submitted at least once). The real-time error is accessible using the `fieldErrors` state from the hook as well.
+
+
 Here is a quick example:
 
 ```tsx
@@ -106,7 +109,7 @@ const Sample = () => {
     // Do whatever you want with fields.
   }
   return (
-    <FieldManager fields={{ field1: "", field2: "", field3: "" }} onValidSubmit={handleValidSubmit} className="custom-form-css">
+    <FieldManager fields={{ field1: "", field2: "", field3: "" }} onValidSubmit={handleValidSubmit} className="custom-form-css" nativeValidation>
       <InputField type="text" name="field1" required pattern="^\w+$" />
       <InputField
         type="number"

--- a/forms/package.json
+++ b/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "description": "Simple library with useful React forms components and browser validation.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/forms/src/FieldManager.tsx
+++ b/forms/src/FieldManager.tsx
@@ -3,11 +3,12 @@ import { FieldManagerContext } from './FieldManagerContext'
 import { useFieldState } from './useFieldState'
 import { FieldManagerForm } from './FieldManagerForm'
 import { ValidatedFormProps } from './ValidatedForm'
+import { FieldValues } from './types'
 
 export type FieldManagerProps = PropsWithChildren & {
-	fields: Record<string, any>
+	fields: FieldValues
 	defaultValues?: Record<string, string>
-	onValidSubmit?: (fields: Record<string, any>) => void
+	onValidSubmit?: (fields: FieldValues) => void
 } & Omit<ValidatedFormProps, 'onValidSubmit'>
 
 /**

--- a/forms/src/FieldManagerForm.test.tsx
+++ b/forms/src/FieldManagerForm.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { InputField } from './Input'
+import { useFieldManager } from './useFieldManager'
+import userEvent from '@testing-library/user-event'
+import { FC, PropsWithChildren } from 'react'
+import { FieldManager } from './FieldManager'
+
+const spySuccess = vi.fn()
+
+const SampleFieldWithRenderError = () => {
+	const { checkFieldError, reset, fieldErrors } = useFieldManager()
+	const error = checkFieldError('field')
+	return (
+		<>
+			<InputField data-testid="field" name="field" required />
+			<button type="submit" data-testid="submit">Submit</button>
+			<button type="button" data-testid="reset" onClick={() => reset()}>Reset</button>
+			{fieldErrors.field && <div data-testid="error-state">{fieldErrors.field}</div>}
+			{error && <div data-testid="error-show">{error}</div>}
+		</>
+	)
+}
+
+const FullyControlledFieldWrapper: FC<PropsWithChildren> = ({ children }) => (
+	<FieldManager fields={{ field: '' }} onValidSubmit={spySuccess}>
+		{children}
+	</FieldManager>
+)
+
+describe('FieldManagerForm', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('should setup validation form and not report any errors if form is valid', async () => {
+		render(<SampleFieldWithRenderError />, { wrapper: FullyControlledFieldWrapper })
+
+		const button = screen.getByTestId('submit')
+		const input = screen.getByTestId('field')
+
+		expect(screen.queryByTestId('error-show')).toBeFalsy()
+
+		await userEvent.type(input, '123')
+
+		expect(screen.queryByTestId('error-show')).toBeFalsy()
+
+		await userEvent.click(button)
+
+		expect(spySuccess).toHaveBeenCalled()
+	})
+
+	it('should setup validation form and report validation after first submit', async () => {
+		render(<SampleFieldWithRenderError />, { wrapper: FullyControlledFieldWrapper })
+
+		const button = screen.getByTestId('submit')
+		const input = screen.getByTestId('field')
+		const reset = screen.getByTestId('reset')
+
+		expect(screen.queryByTestId('error-show')).toBeFalsy()
+		expect(screen.queryByTestId('error-state')).toBeTruthy() // has error but not yet reportable
+
+		await userEvent.click(button) // trigger reportable
+
+		await waitFor(() => {
+			expect(screen.queryByTestId('error-show')).toBeTruthy() // now error shows
+		})
+
+		expect(spySuccess).not.toHaveBeenCalled() // not valid yet.
+
+		await userEvent.type(input, '123') // fix validation error
+
+		expect(screen.queryByTestId('error-show')).toBeFalsy() // error hides.
+
+		await userEvent.click(reset) // reset form state
+
+		expect(screen.queryByTestId('error-show')).toBeFalsy()
+	})
+})

--- a/forms/src/FieldManagerForm.tsx
+++ b/forms/src/FieldManagerForm.tsx
@@ -5,13 +5,16 @@ import { ValidatedForm, ValidatedFormProps } from './ValidatedForm'
 export type ManagedValidatedFormProps = Omit<ValidatedFormProps, 'onValidSubmit'>
 
 export const FieldManagerForm = forwardRef<HTMLFormElement, ManagedValidatedFormProps>(({ children, ...props }, ref) => {
-	const { fields, onValidSubmit } = useFieldManager()
+	const { fields, onValidSubmit, setReportValidation } = useFieldManager()
+	const handleLocalSubmit = () => {
+		setReportValidation(true)
+	}
 	const handleLocalValidSubmit = () => {
 		if (onValidSubmit != null) {
 			onValidSubmit(fields)
 		}
 	}
-	return <ValidatedForm ref={ref} {...props} onValidSubmit={handleLocalValidSubmit}>{children}</ValidatedForm>
+	return <ValidatedForm ref={ref} {...props} onValidSubmit={handleLocalValidSubmit} onSubmit={handleLocalSubmit}>{children}</ValidatedForm>
 })
 
 FieldManagerForm.displayName = 'FieldManagerForm'

--- a/forms/src/Input.tsx
+++ b/forms/src/Input.tsx
@@ -18,12 +18,17 @@ export const Input = forwardRef<Ref, InputProps>(({ onFieldError, fieldError, na
 		localSetError(undefined)
 		e.target.setCustomValidity('')
 		if (onChange != null) onChange(e)
+		if (!localRef.current.validity.valid) localSetError(localRef.current.validationMessage)
 	}
 
 	const handleInvalid = (e) => {
 		localSetError(e.target.validationMessage)
 		if (onInvalid != null) onInvalid(e)
 	}
+
+	useEffect(() => {
+		if (!localRef.current.validity.valid) localSetError(localRef.current.validationMessage)
+	}, [])
 
 	useEffect(() => {
 		if (fieldError !== localRef.current.validationMessage) {

--- a/forms/src/Select.tsx
+++ b/forms/src/Select.tsx
@@ -18,12 +18,17 @@ export const Select = forwardRef<Ref, SelectProps>(({ onFieldError, onInvalid, f
 		localSetError(undefined)
 		e.target.setCustomValidity('')
 		if (onChange != null) onChange(e)
+		if (!localRef.current.validity.valid) localSetError(localRef.current.validationMessage)
 	}
 
 	const handleInvalid = (e) => {
 		localSetError(e.target.validationMessage)
 		if (onInvalid != null) onInvalid(e)
 	}
+
+	useEffect(() => {
+		if (!localRef.current.validity.valid) localSetError(localRef.current.validationMessage)
+	}, [])
 
 	useEffect(() => {
 		if (fieldError !== localRef.current.validationMessage) {

--- a/forms/src/TextArea.tsx
+++ b/forms/src/TextArea.tsx
@@ -18,12 +18,17 @@ export const TextArea = forwardRef<Ref, TextAreaProps>(({ onFieldError, onInvali
 		localSetError(undefined)
 		e.target.setCustomValidity('')
 		if (onChange != null) onChange(e)
+		if (!localRef.current.validity.valid) localSetError(localRef.current.validationMessage)
 	}
 
 	const handleInvalid = (e) => {
 		localSetError(e.target.validationMessage)
 		if (onInvalid != null) onInvalid(e)
 	}
+
+	useEffect(() => {
+		if (!localRef.current.validity.valid) localSetError(localRef.current.validationMessage)
+	}, [])
 
 	useEffect(() => {
 		if (fieldError !== localRef.current.validationMessage) {

--- a/forms/src/types.ts
+++ b/forms/src/types.ts
@@ -9,6 +9,14 @@ export type FieldValues = Record<string, string>
 
 export type UseFieldStateResult = {
 	/**
+	 * Indicates whether InputFields within should render validation errors based on the fieldError state. This is unrelated to the native browser `reportValidity()` function.
+	 */
+	reportValidation: boolean
+	/**
+	 * Set report validation manually. This reportValidation is the managed toggle that indicates whether to render validation error messages based on fieldError state. This is unrelated to the native browser `reportValidity()` function.
+	 */
+	setReportValidation: Dispatch<SetStateAction<boolean>>
+	/**
 	 * Reset a form's error and value states.
 	 */
 	reset: () => void;
@@ -26,6 +34,13 @@ export type UseFieldStateResult = {
 	 * Current field errors where kesy match input names.
 	 */
 	fieldErrors: Record<string, string>;
+
+	/**
+	 * Combines `reportValidation` and the `fieldErrors` state to determine if field requested should show an error.
+	 * @param name Field input name.
+	 * @returns Field error if it has one and should be reported.
+	 */
+	checkFieldError: (name: string) => string | undefined
 	/**
 	 * Set a single field's error
 	 * @param key Field name key

--- a/forms/src/useFieldState.ts
+++ b/forms/src/useFieldState.ts
@@ -12,6 +12,7 @@ import { FieldValues, UseFieldStateResult } from './types'
 export function useFieldState(fields: FieldValues, defaultValues?: FieldValues, onValidSubmit?: (fields: FieldValues) => void): UseFieldStateResult {
 	const defaultFieldValues = defaultValues != null ? defaults(omitBy(fields, (v) => v == null || v === ''), defaultValues) : fields
 
+	const [reportValidation, setReportValidation] = useState(false)
 	const [fieldValues, setFieldValues] = useState<FieldValues>(fields)
 	const [fieldErrors, setFieldErrors] = useState<Record<string, string | undefined>>({})
 
@@ -25,9 +26,15 @@ export function useFieldState(fields: FieldValues, defaultValues?: FieldValues, 
 		setFieldErrors((old) => ({ ...old, [key]: message }))
 	}
 
+	const checkFieldError = (key: string): string | undefined => {
+		if (reportValidation && fieldErrors[key] != null && fieldErrors[key] !== '') return fieldErrors[key]
+		return undefined
+	}
+
 	function reset() {
 		setFieldErrors({})
 		setFieldValues(defaultFieldValues)
+		setReportValidation(false)
 	}
 
 	const handleChange: (_e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => Record<string, string> = (e) => {
@@ -50,14 +57,17 @@ export function useFieldState(fields: FieldValues, defaultValues?: FieldValues, 
 	}
 
 	return {
-		reset,
-		fields: fieldValues,
-		setField,
 		fieldErrors,
-		setFieldError,
-		setFieldErrors,
+		checkFieldError,
+		fields: fieldValues,
 		handleChange,
 		onChange: handleChange, // alias
-		onValidSubmit: localOnValidSubmit
+		onValidSubmit: localOnValidSubmit,
+		reportValidation,
+		reset,
+		setField,
+		setFieldError,
+		setFieldErrors,
+		setReportValidation
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "demo": {
       "name": "@iwsio/forms-demo",
-      "version": "1.0.0",
+      "version": "1.1.0-alpha.1",
       "license": "ISC",
       "dependencies": {
         "serve": "^14.2.1"
@@ -83,7 +83,7 @@
     },
     "forms": {
       "name": "@iwsio/forms",
-      "version": "1.0.0",
+      "version": "1.1.0-alpha.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",


### PR DESCRIPTION
Checking `validity` during `onChange` for a more responsive field error tracking.  However, without relying on `submit` event to trigger `checkValidation` and set error state, I need to find a better way to show the error state when it's ready to show.  In the old days, we had what I'm using here: `was-validated` `needs-validation` but when relying purely on error state, it's probably not appropriate to lean on classNames of parents. (duh). 

Adding `reportValidation` prop to the `useFieldState` hook, which toggles to true after the first submit.

<img width="394" alt="Screenshot 2023-11-09 at 5 20 03 PM" src="https://github.com/iwsllc/iwsio-forms/assets/102517/99bcdee9-aefb-4723-b73d-f4bc8feaff3b">
