### PR TITLE
Better support for remotely managed field state. Adding ControlledFieldManager

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms-demo",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha.1",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.23.5",
@@ -8,6 +8,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@tailwindcss/typography": "^0.5.10",
+    "@tanstack/react-query": "^5.10.0",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.1",

--- a/demo/public/movies.json
+++ b/demo/public/movies.json
@@ -1,0 +1,18 @@
+[
+	{
+		"title": "The Matrix",
+		"year": 1999,
+		"director": "The Wachowski Brothers",
+		"cast": [
+			"Keanu Reeves",
+			"Laurence Fishburne",
+			"Carrie-Anne Moss",
+			"Hugo Weaving"
+		],
+		"genres": [
+			"Action",
+			"Sci-Fi"
+		],
+		"rating": 8.7
+	}
+]

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,10 +1,15 @@
 import { BrowserRouter } from 'react-router-dom'
 import { Routes } from './routes'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+
+const client = new QueryClient()
 
 export const App = () => (
-	<BrowserRouter>
-		<Routes />
-	</BrowserRouter>
+	<QueryClientProvider client={client}>
+		<BrowserRouter>
+			<Routes />
+		</BrowserRouter>
+	</QueryClientProvider>
 )
 
 export default App

--- a/demo/src/common/Nav.tsx
+++ b/demo/src/common/Nav.tsx
@@ -10,5 +10,6 @@ export const Nav = () => (
 		<li><Link to="/examples">Examples</Link></li>
 		<li><Link to="/input">Input Demo</Link></li>
 		<li><Link to="/invalid-feedback">Invalid Feedback</Link></li>
+		<li><Link to="/upstream-test">Async Init</Link></li>
 	</ul>
 )

--- a/demo/src/content/test.md
+++ b/demo/src/content/test.md
@@ -1,1 +1,0 @@
-Experimental page.

--- a/demo/src/content/upstream-test.md
+++ b/demo/src/content/upstream-test.md
@@ -1,0 +1,3 @@
+# Async field values on init
+
+This is a small test to ensure we can update field values from an asynchronous fetch. 

--- a/demo/src/routes.tsx
+++ b/demo/src/routes.tsx
@@ -5,7 +5,7 @@ import { InputDemo } from './samples/InputDemo'
 import { InputCheckDemo } from './samples/InputCheckDemo'
 import { RawExamples } from './samples/RawExamples'
 import { InvalidFeedbackDemo } from './samples/InvalidFeedback'
-import { UpstreamChangesTest } from './samples/UpstreamChangesTest'
+import { UpstreamChangesPage } from './samples/UpstreamChangesTest'
 
 export const Routes = () => {
 	return (
@@ -18,7 +18,7 @@ export const Routes = () => {
 				<Route path="input-check-radio" element={<FetchPage page="input-check-radio" demo={<InputCheckDemo />} />} />
 				<Route path="select" element={<FetchPage page="select" demo={<InputDemo />} />} />
 				<Route path="textarea" element={<FetchPage page="textarea" demo={<InputDemo />} />} />
-				<Route path="upstream-test" element={<FetchPage page="test" demo={<UpstreamChangesTest />} />} />
+				<Route path="upstream-test" element={<FetchPage page="upstream-test" demo={<UpstreamChangesPage />} />} />
 				<Route path=":page" element={<FetchPage />} />
 			</Route>
 		</ReactRoutes>

--- a/demo/src/samples/fetchSample.ts
+++ b/demo/src/samples/fetchSample.ts
@@ -1,0 +1,3 @@
+export const fetchMovies = async () => {
+	return (await fetch('/movies.json')).json() // just a quick example
+}

--- a/forms/README.md
+++ b/forms/README.md
@@ -130,6 +130,38 @@ const Sample = () => {
 }
 ```
 
+
+## `<ControlledFieldManager>`
+
+You might be wondering, how do I manage field state outside of the FieldManager? Imagine a scenario where these field values may be managed upstream in your application. Maybe they're being pulled in from an asynchronous request and loaded after the form renders. In this case, you'll want to manage the field state outside of the FieldManager component. For this, there is another component you can use. `<ControlledFieldManager/>` where you provide the fieldState yourself.
+
+```tsx
+export const DelayedFieldValuesTest = () => {
+	const handleValidSubmit = (values: FieldValues) => {
+		console.log(values)
+	}
+  // use this hook directly to set initail field values.
+	const fieldState = useFieldState({ name: '', email: '', phone: '' }, undefined, handleValidSubmit)
+	const { setFields } = fieldState
+
+	useEffect(() => {
+    // simple delay to emulate a network request or some other delay getting values
+		const id = setTimeout(() => {
+			setFields({ name: 'John Doe', email: 'test@example.com', phone: '1234567890' })
+		}, 250)
+		return () => clearTimeout(id)
+	}, [])
+
+	return (
+		<ControlledFieldManager fieldState={fieldState}>
+			<InputField placeholder="Name" name="name" type="text" className="input input-bordered" required />
+			<InputField placeholder="Phone" name="phone" type="text" pattern="^\d+$" className="input input-bordered" required />
+			<InputField placeholder="Email" name="email" type="email" className="input input-bordered" required />
+		</ControlledFieldManager>
+	)
+}
+```
+
 ## `<InvalidFeedbackForField />`
 One last component: this is just a helper component to display errors using the `useFieldState` properties mentioned above. Feel free to use this an example to make your own or consume it as-is. It currently returns a `<span/>` containing the error with any additional span attributes you provide as props. It consumes `checkFieldError(name)` to determine when to render and will return `null` when no error exists. You'll likely want to disable native validation reporting if you use this. Set `nativeValidation={false}` on the `ValidatedForm` or `FieldManager`, whichever one you use.
 

--- a/forms/package.json
+++ b/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha.1",
   "description": "Simple library with useful React forms components and browser validation.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/forms/src/FieldManager.test.tsx
+++ b/forms/src/FieldManager.test.tsx
@@ -1,6 +1,8 @@
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { FieldManager, Input } from '.'
+import { useFieldState } from './useFieldState'
+import { ControlledFieldManager, FieldManager } from './FieldManager'
+import { Input, InputField } from './Input'
 
 describe('FieldManager', () => {
 	test('When rendering field manager with fields; happy path', async () => {
@@ -42,5 +44,71 @@ describe('FieldManager', () => {
 		})
 
 		expect(input.value).to.eq('123') // bindings made, state updated and the input is controlled
+	})
+})
+
+describe('ControlledFieldManager', () => {
+	test('When rendering field manager with fields; happy path', async () => {
+		const Test = () => {
+			const fieldState = useFieldState({ field: '' })
+			return <ControlledFieldManager fieldState={fieldState}><InputField data-testid="field" name="field" /></ControlledFieldManager>
+		}
+		render(<Test />)
+
+		const input = screen.getByTestId('field') as HTMLInputElement
+		expect(input.value).to.eq('')
+
+		await act(async () => {
+			await userEvent.type(input, '123')
+		})
+
+		expect(input.value).to.eq('123') // bindings made, state updated and the input is controlled
+	})
+
+	test('When rendering field manager with no fields', async () => {
+		const Test = () => {
+			const fieldState = useFieldState({ field: '' })
+			return <ControlledFieldManager fieldState={fieldState} />
+		}
+		const { container } = render(<Test />)
+
+		expect(container.textContent).to.eq('')
+	})
+
+	test('When rendering field manager with manually controlled field', async () => {
+		const Test = () => {
+			const fieldState = useFieldState({ field1: '' })
+			const { handleChange } = fieldState
+			return <ControlledFieldManager fieldState={fieldState}><Input data-testid="field1" name="field1" onChange={handleChange} value={fieldState.fields.field1} /></ControlledFieldManager>
+		}
+		render(<Test />)
+
+		// input field2 is an uncontrolled field in this case.
+		const input = screen.getByTestId('field1') as HTMLInputElement
+		expect(input.value).to.eq('')
+
+		await act(async () => {
+			await userEvent.type(input, '123')
+		})
+
+		expect(input.value).to.eq('123') // bindings made, state updated and the input is controlled
+	})
+
+	test('When rendering field manager with uncontrolled field', async () => {
+		const Test = () => {
+			const fieldState = useFieldState({ field: '' })
+			return <ControlledFieldManager fieldState={fieldState}><Input data-testid="field2" name="field2" /></ControlledFieldManager>
+		}
+		render(<Test />)
+
+		// input field2 is an uncontrolled field in this case.
+		const input = screen.getByTestId('field2') as HTMLInputElement
+		expect(input.value).to.eq('')
+
+		await act(async () => {
+			await userEvent.type(input, '123')
+		})
+
+		expect(input.value).to.eq('123') // field still works as normal
 	})
 })

--- a/forms/src/FieldManager.tsx
+++ b/forms/src/FieldManager.tsx
@@ -38,3 +38,19 @@ export const FieldManager = forwardRef<HTMLFormElement, FieldManagerProps>(({ ch
 	)
 })
 FieldManager.displayName = 'FieldManager'
+
+export type ControlledFieldManagerProps = Omit<FieldManagerProps, 'fields' | 'defaultValues' | 'onValidSubmit'> & { fieldState: ReturnType<typeof useFieldState>}
+
+/**
+ * Use this component if you want to manage field state remotely. This is useful when you're setting up form context elswhere and want the field values to change from outside input interactions.
+ */
+export const ControlledFieldManager = forwardRef<HTMLFormElement, ControlledFieldManagerProps>(({ children, fieldState, ...props }, ref) => {
+	return (
+		<FieldManagerContext.Provider value={fieldState}>
+			<FieldManagerForm ref={ref} {...props}>
+				{children}
+			</FieldManagerForm>
+		</FieldManagerContext.Provider>
+	)
+})
+ControlledFieldManager.displayName = 'ControlledFieldManager'

--- a/forms/src/useFieldState.test.ts
+++ b/forms/src/useFieldState.test.ts
@@ -131,6 +131,25 @@ describe('useFieldState', () => {
 		})
 	})
 
+	test('When changing one field', async () => {
+		const fieldValues = { firstName: '', lastName: '' }
+		const defaultValues = { firstName: 'fred', lastName: 'flintstone' }
+
+		const hook = renderHook(() => useFieldState(fieldValues, defaultValues))
+
+		const { result } = hook
+		expect(result.current.fields.firstName).toEqual('')
+		expect(result.current.fields.lastName).toEqual('')
+
+		act(() => {
+			result.current.setField('firstName', 'fred2')
+		})
+
+		await waitFor(() => {
+			expect(result.current.fields.firstName).toEqual('fred2')
+		})
+	})
+
 	test('When changing many fields at once (all fields)', async () => {
 		const fieldValues = { firstName: '', lastName: '' }
 		const defaultValues = { firstName: 'fred', lastName: 'flintstone' }
@@ -168,6 +187,93 @@ describe('useFieldState', () => {
 		await waitFor(() => {
 			expect(result.current.fields.firstName).toEqual('fred2')
 			expect(result.current.fields.lastName).toEqual('')
+		})
+	})
+
+	describe('Changing fields with existing errors', () => {
+		test('When changing one field', async () => {
+			const fieldValues = { firstName: '', lastName: '' }
+			const defaultValues = { firstName: 'fred', lastName: 'flintstone' }
+
+			const hook = renderHook(() => useFieldState(fieldValues, defaultValues))
+
+			const { result } = hook
+			expect(result.current.fields.firstName).toEqual('')
+			expect(result.current.fields.lastName).toEqual('')
+
+			act(() => {
+				result.current.setFieldError('firstName', 'This field is required')
+			})
+			expect(result.current.fieldErrors.firstName).toEqual('This field is required')
+
+			act(() => {
+				result.current.setField('firstName', 'fred2')
+			})
+			expect(result.current.fieldErrors.firstName).to.not.be.ok
+
+			await waitFor(() => {
+				expect(result.current.fields.firstName).toEqual('fred2')
+			})
+		})
+
+		test('When changing many fields at once (all fields)', async () => {
+			const fieldValues = { firstName: '', lastName: '' }
+			const defaultValues = { firstName: 'fred', lastName: 'flintstone' }
+
+			const hook = renderHook(() => useFieldState(fieldValues, defaultValues))
+
+			const { result } = hook
+			expect(result.current.fields.firstName).toEqual('')
+			expect(result.current.fields.lastName).toEqual('')
+
+			act(() => {
+				result.current.setFieldError('firstName', 'This field is required')
+				result.current.setFieldError('lastName', 'This field is required')
+			})
+			expect(result.current.fieldErrors.firstName).toEqual('This field is required')
+			expect(result.current.fieldErrors.lastName).toEqual('This field is required')
+
+			act(() => {
+				result.current.setFields({ firstName: 'fred2', lastName: 'flintstone2' })
+			})
+
+			expect(result.current.fieldErrors.firstName).not.to.be.ok
+			expect(result.current.fieldErrors.lastName).not.to.be.ok
+
+			await waitFor(() => {
+				expect(result.current.fields.firstName).toEqual('fred2')
+				expect(result.current.fields.lastName).toEqual('flintstone2')
+			})
+		})
+
+		test('When changing many fields at once (some fields)', async () => {
+			const fieldValues = { firstName: '', lastName: '' }
+			const defaultValues = { firstName: 'fred', lastName: 'flintstone' }
+
+			const hook = renderHook(() => useFieldState(fieldValues, defaultValues))
+
+			const { result } = hook
+			expect(result.current.fields.firstName).toEqual('')
+			expect(result.current.fields.lastName).toEqual('')
+
+			act(() => {
+				result.current.setFieldError('firstName', 'This field is required')
+				result.current.setFieldError('lastName', 'This field is required')
+			})
+			expect(result.current.fieldErrors.firstName).toEqual('This field is required')
+			expect(result.current.fieldErrors.lastName).toEqual('This field is required')
+
+			act(() => {
+				result.current.setFields({ firstName: 'fred2' })
+			})
+
+			expect(result.current.fieldErrors.firstName).not.to.be.ok
+			expect(result.current.fieldErrors.lastName).toEqual('This field is required')
+
+			await waitFor(() => {
+				expect(result.current.fields.firstName).toEqual('fred2')
+				expect(result.current.fields.lastName).toEqual('')
+			})
 		})
 	})
 })

--- a/forms/src/useFieldState.ts
+++ b/forms/src/useFieldState.ts
@@ -21,6 +21,7 @@ export function useFieldState(fields: FieldValues, defaultValues?: FieldValues, 
 
 	const setField = useCallback((key: string, value: string) => {
 		setFieldValues((oldFields) => ({ ...oldFields, [key]: value }))
+		setFieldError(key, undefined) // clear this error if one exists.
 	}, [])
 
 	const setFields = useCallback((values: Partial<FieldValues>) => {
@@ -30,6 +31,14 @@ export function useFieldState(fields: FieldValues, defaultValues?: FieldValues, 
 				if (values[key] != null) newFields[key] = values[key] // only set fields provided
 			}
 			return newFields
+		})
+		// clear errors for fields provided when setting fields
+		setFieldErrors((oldErrors) => {
+			const newErrors = { ...oldErrors }
+			for (const key in values) {
+				if (values[key] != null) delete newErrors[key]
+			}
+			return newErrors
 		})
 	}, [])
 
@@ -58,7 +67,7 @@ export function useFieldState(fields: FieldValues, defaultValues?: FieldValues, 
 		}
 
 		setFieldValues((old) => {
-			const newValues = { ...old } as Record<string, string>
+			const newValues = { ...old } as FieldValues
 			newValues[name] = value
 			updatedFields = newValues
 			return newValues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iwsio/forms-root",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iwsio/forms-root",
-      "version": "2.1.0",
+      "version": "2.2.0-alpha.1",
       "license": "BSD-3-Clause",
       "workspaces": [
         "forms",
@@ -22,7 +22,7 @@
     },
     "demo": {
       "name": "@iwsio/forms-demo",
-      "version": "2.1.0",
+      "version": "2.2.0-alpha.1",
       "license": "ISC",
       "dependencies": {
         "serve": "^14.2.1"
@@ -33,6 +33,7 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@tailwindcss/typography": "^0.5.10",
+        "@tanstack/react-query": "^5.10.0",
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.5.1",
@@ -82,7 +83,7 @@
     },
     "forms": {
       "name": "@iwsio/forms",
-      "version": "2.1.0",
+      "version": "2.2.0-alpha.1",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
@@ -2798,6 +2799,32 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.10.0.tgz",
+      "integrity": "sha512-wlw/l2E+U70iABaJnOtZIJN/5VMhuj4RPViafwUYiIGoqw1VqqqaxBnBL90qLhWswoOaK8RAj3+NiG0duk+cRg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.10.0.tgz",
+      "integrity": "sha512-LeJsyXUvhq1TBsEbt3SSEaxP2Att1sv/qW588GL/bvjxPxsLUBWKGuFJ5Z1YP+/nJqVmcXJE8AtvZaaxE9rsKQ==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iwsio/forms-root",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha.1",
   "description": "Simple library with useful React forms components and browser validation.",
   "files": [],
   "engines": {


### PR DESCRIPTION
Quick lunchtime PR. 

 - ControlledFieldManager - enable remote fieldState
 - Demo update; adding sample to show how this works with a fetch query for input field data.
 - Tests for coverage.